### PR TITLE
Don't need to do `write` before `end`.

### DIFF
--- a/example/socketio.js
+++ b/example/socketio.js
@@ -16,8 +16,7 @@ var server = http.createServer(function (req, res) {
 	    fs.readFile(__dirname + path, function(err, data){
 		if (err) return send404(res);
 		res.writeHead(200, {'Content-Type': 'text/html'});
-		res.write(data, 'utf8');
-		res.end();
+		res.end(data);
 	    });
 	    break;
 	default: send404(res);
@@ -26,8 +25,7 @@ var server = http.createServer(function (req, res) {
 
 send404 = function(res){
 	res.writeHead(404);
-	res.write('404');
-	res.end();
+	res.end('404');
 };
 
 var socketserver = io.listen(server);

--- a/example/sockjs.js
+++ b/example/sockjs.js
@@ -14,8 +14,7 @@ var httpserver = http.createServer(function (req, res) {
     fs.readFile(__dirname + '/sockjs.html', function(err, data) {
       if (err) return send404(res);
       res.writeHead(200, {'Content-Type': 'text/html'});
-      res.write(data, 'utf8');
-      res.end();
+      res.end(data);
     });
     break;
   default: send404(res);
@@ -24,8 +23,7 @@ var httpserver = http.createServer(function (req, res) {
 
 send404 = function(res) {
 	res.writeHead(404);
-	res.write('404');
-	res.end();
+	res.end('404');
 };
 
 // Listen for SockJS connections


### PR DESCRIPTION
Looking at http://nodejs.org/docs/v0.4.10/api/all.html#response.end , it seems we can (and should) avoid doing 'write' just before 'end'. This is also more performant (less packets on the wire).
