### PR TITLE
Expose more for REQ-REP

### DIFF
--- a/lib/sockets.js
+++ b/lib/sockets.js
@@ -131,13 +131,13 @@ function Socket(connection) {
     this._encoding = encoding;
   }
 
-  proto.write = function(data /*, encoding */) {
+  proto.write = function(data, opts /*, encoding */) {
     // NB flow control as complement to above (may need to expose the
     // underlying TCP flow control via the AMQP client)
-    if (arguments.length > 1) {
-      return this._send(new Buffer(data, arguments[1]));
+    if (arguments.length > 2) {
+      return this._send(new Buffer(data, arguments[2]), opts);
     }
-    return this._send(data);
+    return this._send(data, opts);
   }
 
   proto.end = function() {
@@ -150,12 +150,12 @@ function Socket(connection) {
 
   /* =============== end public API */
 
-  proto._recv = function(data) {
+  proto._recv = function(data, msg) {
     if (this._pause) {
       this._buffer.push(data);
     }
     else {
-      this._emitData(data);
+      this._emitData(data, msg);
     }
   }
 
@@ -167,9 +167,9 @@ function Socket(connection) {
     }
   }
 
-  proto._emitData = function(data) {
+  proto._emitData = function(data, msg) {
     data = (this._encoding) ? data.toString(this._encoding) : data;
-    this.emit('data', data);
+    this.emit('data', data, msg);
   }
 
   // Serves a dual-role: if exchange is empty, treat it as a
@@ -223,14 +223,19 @@ function Socket(connection) {
     }
   }
 
-  proto._sendOne = function(buf) {
+  proto._sendOne = function(buf, opts) {
     if (this.writable) {
       var ad = this._advertisements.shift();
       if (ad) {
         // we treat the private queue as our reply queue; so if there
         // is one, use it in reply-to.
-        options = (this._privateQueue) ?
+        var options = (this._privateQueue) ?
           {'replyTo': this._privateQueue.name} : {};
+
+        // MJW: Merge options here...
+        if (opts.headers) options.headers = opts.headers;
+        if (opts.messageId) options.messageId = opts.messageId;
+
         ad.exchange.publish(ad.routingKey, buf, options);
         this._advertisements.push(ad);
       }
@@ -299,7 +304,7 @@ function Socket(connection) {
         if (that._replies) {
           that._replies.push(msg.replyTo);
         }
-        that._recv(data);
+        that._recv(data, msg);
         data = null;
       });
     }).addCallback(function(ok) {
@@ -321,7 +326,7 @@ function Socket(connection) {
       that.emit('end');
     }
 
-    for (name in this._subscriptions) {
+    for (var name in this._subscriptions) {
       var sub = this._subscriptions[name];
       delete this._subscriptions[name];
       latch++;
@@ -439,12 +444,12 @@ RepSocket.prototype.connect = function(queue, callback) {
     if (callback) callback();
   });
 }
-RepSocket.prototype._send = function(data) {
+RepSocket.prototype._send = function(data, opts) {
   // WARNING this requires good behaviour on the part of
   // clients. Specifically: each request must have exactly one reply,
   // and they must be made in order they are sent down the wire. The
   // alternative is to be more like dealer/router, which requires
   // multi-part messages or some prefixing scheme.
   var replyQueue = this._replies.shift();
-  this._exchange.publish(replyQueue, data);
+  this._exchange.publish(replyQueue, data, opts);
 }


### PR DESCRIPTION
From BDD testing using Mocha and them integration testing against RabbitMQ and a .NET receiver, I needed more access to control the AMQP options and get the headers on the responses.
