### PR TITLE
Use sockjs 0.2

### DIFF
--- a/example/sockjs/index.html
+++ b/example/sockjs/index.html
@@ -1,7 +1,7 @@
 <html>
   <head>
     <title>SockJS example</title>
-    <script src="http://cdn.sockjs.org/sockjs-0.1.min.js"></script>
+    <script src="http://cdn.sockjs.org/sockjs-0.2.min.js"></script>
   </head>
   <body>
     <script>

--- a/example/sockjs/package.json
+++ b/example/sockjs/package.json
@@ -2,6 +2,6 @@
   "name": "rabbit.js-sockjs-example",
   "version": "0.0.0",
   "dependencies": {
-    "sockjs": "*"
+    "sockjs": "0.2.x"
   }
 }

--- a/example/sockjs/server.js
+++ b/example/sockjs/server.js
@@ -21,7 +21,7 @@ var context = require('../../index').createContext('amqp://localhost:5672');
 // for SockJS connections.
 var httpserver = http.createServer(handler);// Listen for SockJS connections
 var sockjs_opts = {
-  sockjs_url: "http://sockjs.github.com/sockjs-client/sockjs-latest.min.js"};
+  sockjs_url: "http://cdn.sockjs.org/sockjs-0.2.min.js"};
 var sjs = sockjs.createServer(sockjs_opts);
 sjs.installHandlers(httpserver, {prefix: '[/]socks'});
 


### PR DESCRIPTION
In current sockjs example rabbit.js uses sockjs-latest in one place and sockjs-0.1 in the other.

It would be nice to pin the example to use sockjs 0.2
