### PR TITLE
Fix stream API link in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ and connect it to something:
     sub.connect('alerts');
 
 Sockets act like
-[Streams](http://nodejs.org/docs/latest/api/streams.html); in
+[Streams](http://nodejs.org/docs/latest/api/stream.html); in
 particular you will get `'data'` events from those that are readable,
 and you can `write()` to those that are writable. If you're expecting
 data that is encoded strings, you can `setEncoding()` to get strings


### PR DESCRIPTION
A link in the README was pointing to the 'streams.html' file in the Node.js API docs, but it is in fact 'stream.html'.
