### PR TITLE
Pass along connection error events.

### DIFF
--- a/lib/sockets.js
+++ b/lib/sockets.js
@@ -15,6 +15,7 @@ function Context(url) {
   var that = this;
   var c = this._connection = amqp.createConnection({url: url});
   c.on('ready', function() { that.emit('ready') });
+  c.on('error', function(e) { that.emit('error', e) });
 };
 
 var SOCKETS = {


### PR DESCRIPTION
Right now the only way to detect a connection error (aside from you app exploding) is by doing:

```
var context = rabbitjs.createContext(server.uri);
context._connection.on('error', function(err) {});
```

This should really be exposed to the context object:

```
var context = rabbitjs.createContext(server.uri);
context.on('error', function(err) {});
```

Thanks!
