### PR TITLE
change amqp dependency to precise, compatible commit rather than the npm registry

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,6 @@
     "node": ">=0.6"
   },
   "dependencies": {
-    "amqp": "~0.1.3"
+    "amqp": "git+https://github.com/postwait/node-amqp.git#80fc04991a"
   }
 }


### PR DESCRIPTION
so as not to require the annoying behavior of grabbing the tarred source and installing manually
