### PR TITLE
Full control over queue, exchange and message setup options.

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,9 @@
 var sockets = require('./lib/sockets');
 
-module.exports.createContext = function(url) {
-  return new sockets.Context(url);
-}
+module.exports.createContext = function(opts) {
+  return new sockets.Context(opts);
+};
+
+module.exports.Settings = sockets.Settings;
+module.exports.Exchange = sockets.Exchange;
+module.exports.Queue = sockets.Queue;

--- a/lib/sockets.js
+++ b/lib/sockets.js
@@ -2,6 +2,7 @@ var amqp = require('amqp');
 var util = require('util');
 var EventEmitter = require('events').EventEmitter;
 var Stream = require('stream').Stream;
+var extend = require('xtend');
 
 var debug = (process.env['DEBUG']) ?
     function(msg) { util.debug(msg) } : function() {};
@@ -10,10 +11,10 @@ var info = util.log;
 
 debug('on');
 
-function Context(url) {
+function Context(opts) {
   EventEmitter.constructor.call(this);
   var that = this;
-  var c = this._connection = amqp.createConnection({url: url});
+  var c = this._connection = amqp.createConnection(opts);
   c.on('ready', function() { that.emit('ready') });
   c.on('error', function(e) { that.emit('error', e) });
 };
@@ -30,10 +31,10 @@ var SOCKETS = {
 (function(proto) {
   Context.prototype = proto;
 
-  proto.socket = function(type) {
+  proto.socket = function(type, qOpts, opts) {
     var Ctr = SOCKETS[type];
     if (Ctr) {
-      return new Ctr(this._connection);
+      return new Ctr(this._connection, qOpts, opts);
     }
     else throw('Undefined socket type ' + type);
   };
@@ -42,12 +43,134 @@ var SOCKETS = {
 
 module.exports.Context = Context;
 
-function Socket(connection) {
+module.exports.Settings = {
+QueueOptions : function QueueOptions(options) {
+    if (!(this instanceof QueueOptions)) return new QueueOptions(options);
+
+    this.passive = false;
+    // If set, the server will not create the queue.
+    // The client can use this to check whether a queue exists without modifying the server state.
+    this.durable = false;
+    // Durable queues remain active when a server restarts.
+    // Non-durable queues (transient queues) are purged if/when a server restarts.
+    // Note that durable queues do not necessarily hold persistent messages, although it does not make
+    // sense to send persistent messages to a transient queue.
+    this.exclusive = false;
+    // Exclusive queues may only be consumed from by the current connection.
+    // Setting the 'exclusive' flag always implies 'autoDelete'.
+    this.autoDelete = true;
+    // If set, the queue is deleted when all consumers have finished using it.
+    // Last consumer can be cancelled either explicitly or because its channel is closed.
+    // If there was no consumer ever on the queue, it won't be deleted.
+    this.noDeclare = false;
+    // If set, the queue will not be declared,
+    // this will allow a queue to be deleted if you dont know its previous options.
+    this.arguments = {};
+    // a map of additional arguments to pass in when creating a queue.
+    this.closeChannelOnUnsubscribe = false;
+    // When true the channel will close on unsubscrube, default false.
+
+    if (options) extend(this, options);
+},
+
+ExchangeOptions : function ExchangeOptions(options) {
+    if (!(this instanceof ExchangeOptions)) return new ExchangeOptions(options);
+
+    this.type = 'topic';
+    // the type of exchange 'direct', 'fanout', or 'topic'.
+    this.passive = false;
+    // If set, the server will not create the exchange. The client can use this to check whether
+    // an exchange exists without modifying the server state.
+    this.durable = false;
+    // If set when creating a new exchange, the exchange will be marked as durable.
+    // Durable exchanges remain active when a server restarts.
+    // Non-durable exchanges (transient exchanges) are purged if/when a server restarts.
+    this.autoDelete = true;
+    // If set, the exchange is deleted when there are no longer queues bound to it.
+    this.noDeclare = false;
+    // If set, the exchange will not be declared, this will allow the exchange
+    // to be deleted if you dont know its previous options.
+    this.confirm = false;
+    // If set, the exchange will be in confirm mode, and you will get a 'ack'|'error' event emitted on a publish,
+    // or the callback on the publish will be called.
+
+    if (options) extend(this, options);
+},
+
+MessageOptions : function MessageOptions(options) {
+    if (!(this instanceof MessageOptions)) return new MessageOptions(options);
+
+    this.mandatory = false;
+    // Tells the server how to react if the message cannot be routed to a queue.
+    // If this flag is set, the server will return an unroutable message with a Return method.
+    // If this flag is false, the server silently drops the message.
+    this.immediate = false;
+    // Tells the server how to react if the message cannot be routed to a queue consumer immediately.
+    // If this flag is set, the server will return an undeliverable message with a Return method.
+    // If this flag is false, the server will queue the message, but with no guarantee that it will ever be consumed.
+    this.contentType = 'application/octet-stream';
+    this.contentEncoding = 'utf8';
+    this.headers = {};
+    // Arbitrary application-specific message headers.
+    this.deliveryMode = 1;
+    // Non-persistent (1) or persistent (2)
+    this.priority = 1;
+    // The message priority, 1 to 9.
+
+    // NOTE: Following values can be set via 'options'.
+    //       They MUST contain valid strings and CANNOT be empty or null.
+    //this.replyTo = 'queue name';
+    //this.expiration = '5000'; //in ms. If '0' message will be dropped immediately.
+    //this.timestamp = 0; //64-bit POSIX time_t format
+    //this.correlationId = 'id';
+    //this.messageId = 'id';
+    //this.userId = 'id';
+    //this.appId = 'id';
+
+    if (options) extend(this, options);
+},
+
+DeleteOptions : function DeleteOptions(options) {
+    if (!(this instanceof DeleteOptions)) return new DeleteOptions(options);
+
+    this.ifUnused = false;
+    // If set, deletes the queue only if there are no other consumers.
+    this.ifEmpty = false;
+    // If set, deletes the queue if there are no more messages in it.
+
+    if (options) extend(this, options);
+}
+};
+
+module.exports.Exchange = function Exchange(name, options) {
+    if (!(this instanceof Exchange)) return new Exchange(name, options);
+
+    this.name = name || DEFAULT_EXCHANGE;
+    this.options = options || new Settings.ExchangeOptions();
+};
+
+module.exports.Queue = function Queue(name, options) {
+    if (!(this instanceof Queue)) return new Queue(name, options);
+
+    if (!name) throw "Queue name not specified.";
+    this.name = name;
+    this.options = options || new Settings.QueueOptions();
+};
+
+var DEFAULT_EXCHANGE = '';
+var DEFAULT_QUEUE = '';
+var DEFAULT_ROUTING_KEY = '';
+var DEFAULT_OPTIONS = {};
+var DEFAULT_QUEUE_OPTIONS = new module.exports.Settings.QueueOptions();
+var DEFAULT_EXCHANGE_OPTIONS = new module.exports.Settings.ExchangeOptions();
+var DEFAULT_MESSAGE_OPTIONS = new module.exports.Settings.MessageOptions();
+var DEFAULT_DELETE_OPTIONS = new module.exports.Settings.DeleteOptions();
+
+function Socket(connection, opts) {
   this._pause = false;
   this._buffer = [];
-  this._acceptOpt = {};
-  this._opts = {};
-
+  this._acceptOpt = DEFAULT_OPTIONS;
+  this._opts = opts || DEFAULT_OPTIONS;
   this.readable = this.writable = false;
   //subtypes expected to set these in connect (or a callback therein)
 
@@ -98,7 +221,7 @@ function Socket(connection) {
 
   /* Public Stream API */
 
-  proto.destroy = function() {
+  proto.destroy = function(deleteQueue, deleteOptions) {
     this.writable = false;
     this.readable = false;
     // Let any unconsumed message be requeued (NB if it's an
@@ -106,7 +229,7 @@ function Socket(connection) {
     // However there still may be messages to deliver; let the
     // callback in _cancel emit 'end'.
     this.end();
-    this._cancel();
+    this._cancel(deleteQueue, deleteOptions);
   }
 
   proto.destroySoon = function() {
@@ -131,13 +254,16 @@ function Socket(connection) {
     this._encoding = encoding;
   }
 
-  proto.write = function(data /*, encoding */) {
+  proto.write = function(data, routeKey, messageOptions, encoding /*, 'utf8' */) {
     // NB flow control as complement to above (may need to expose the
     // underlying TCP flow control via the AMQP client)
-    if (arguments.length > 1) {
-      return this._send(new Buffer(data, arguments[1]));
+    if (routeKey) {
+        this.setsockopt('topic', routeKey);
     }
-    return this._send(data);
+    if (encoding) {
+      return this._send(new Buffer(data, encoding), messageOptions);
+    }
+    return this._send(data, messageOptions);
   }
 
   proto.end = function() {
@@ -150,12 +276,12 @@ function Socket(connection) {
 
   /* =============== end public API */
 
-  proto._recv = function(data) {
+  proto._recv = function(data, msg) {
     if (this._pause) {
       this._buffer.push(data);
     }
     else {
-      this._emitData(data);
+      this._emitData(data, msg);
     }
   }
 
@@ -167,51 +293,43 @@ function Socket(connection) {
     }
   }
 
-  proto._emitData = function(data) {
+  proto._emitData = function(data, msg) {
     data = (this._encoding) ? data.toString(this._encoding) : data;
-    this.emit('data', data);
+    this.emit('data', data, msg);
   }
 
-  // Serves a dual-role: if exchange is empty, treat it as a
-  // queue-publish.
-  proto._advertise = function(exchange, routingKey, callback) {
-    var that = this;
-
-    function addToAdvertisements(ex) {
-      var ads = that._advertisements, len = ads.length;
-      for (var i = 0; i < len; i++) {
-        var ad = ads[i];
-        if (ad.exchange.name == ex.name &&
-            ad.routingKey == routingKey) {
-          return;
+  proto._addToAdvertisements = function(ex, key) {
+        var ads = this._advertisements, len = ads.length;
+        for (var i = 0; i < len; i++) {
+            var ad = ads[i];
+            if (ad.exchange.name === ex.name &&
+                ad.routingKey === key) {
+                return;
+            }
         }
-      }
-      ads.push({'exchange': ex, 'routingKey': routingKey});
-    }
+        ads.push({'exchange': ex, 'routingKey': key});
+  }
 
-    if (!exchange) {
-      this._connection.queue(
-        routingKey,
-        {durable: true, autoDelete: false},
-        function (q) {
-          addToAdvertisements(that._connection.exchange());
-          if (callback) callback();
+    proto._advertiseQueue = function(queue, callback) {
+        var that = this;
+        var queueName = ((queue) && (queue.name)) ? queue.name : DEFAULT_QUEUE;
+        var queueOptions = ((queue) && (queue.options)) ? queue.options : DEFAULT_QUEUE_OPTIONS;
+        this._connection.queue(queueName, queueOptions, function (q) {
+            that._addToAdvertisements(that._connection.exchange());
+            if (callback) callback();
         });
-    }
-    else {
-      var exchangeName, exchangeType;
-      exchangeName = exchange.exchange || exchange || 'amq.fanout';
-      exchangeType = exchange.routing || 'fanout';
-      this._connection.exchange(
-        exchangeName,
-        {type: exchangeType},
-        function(ex) {
-          // We want this to behave a bit like a set too.
-          addToAdvertisements(ex);
-          if (callback) callback();
-        });
-    }
-  };
+    };
+
+  proto._advertiseExchange = function(exchange, callback) {
+    var that = this;
+    var exchangeName = ((exchange) && (exchange.name)) ? exchange.name : DEFAULT_EXCHANGE;
+    var exchangeOptions = ((exchange) && (exchange.options)) ? exchange.options : DEFAULT_EXCHANGE_OPTIONS;
+    this._connection.exchange(exchangeName, exchangeOptions, function(ex) {
+      // We want this to behave a bit like a set too.
+      that._addToAdvertisements(ex);
+      if (callback) callback();
+    });
+  }
 
   proto._send = function(_buf) {
     if (this.writable) {
@@ -223,15 +341,20 @@ function Socket(connection) {
     }
   }
 
-  proto._sendOne = function(buf) {
+  proto._sendOne = function(buf, messageOptions) {
     if (this.writable) {
       var ad = this._advertisements.shift();
       if (ad) {
         // we treat the private queue as our reply queue; so if there
         // is one, use it in reply-to.
-        var options = (this._privateQueue) ?
-          {'replyTo': this._privateQueue.name} : {};
-        ad.exchange.publish(ad.routingKey, buf, options);
+        if (!messageOptions) messageOptions = DEFAULT_MESSAGE_OPTIONS;
+        if ((this._privateQueue) && 
+			(this._privateQueue.name) && 
+			(!messageOptions.replyTo)) {
+            //set with private queue name
+            messageOptions.replyTo = this._privateQueue.name;
+        }
+        ad.exchange.publish(ad.routingKey, buf, messageOptions);
         this._advertisements.push(ad);
       }
       return true;
@@ -241,46 +364,50 @@ function Socket(connection) {
     }
   }
 
-  proto._consumeShared = function(queueName, callback) {
+  proto._consumeShared = function(queue, callback) {
     var that = this;
-    return that._connection.queue(
-      queueName, { durable: true, autoDelete: false },
-      function(q) {
+    var queueName = ((queue) && (queue.name)) ? queue.name : DEFAULT_QUEUE;
+    var queueOptions = ((queue) && (queue.options)) ? queue.options : DEFAULT_QUEUE_OPTIONS;
+    return that._connection.queue(queueName, queueOptions, function(q) {
         that._subscribe(q, callback);
-      });
+    });
   };
 
-  proto._consumePrivate = function(bindExchange, callback) {
+  proto._consumePrivate = function(exchange, routingKey, queue, callback) {
     var that = this;
-    var exchangeName, bindingKey, exchangeType;
-    exchangeName = bindExchange.exchange || bindExchange || 'amq.fanout';
-    bindingKey = bindExchange.pattern || '';
-    exchangeType = bindExchange.routing || 'fanout';
+    var exchangeName = ((exchange) && (exchange.name)) ? exchange.name : DEFAULT_EXCHANGE;
+    var exchangeOptions = ((exchange) && (exchange.options)) ? exchange.options : DEFAULT_EXCHANGE_OPTIONS;
+    var queueName = ((queue) && (queue.name)) ? queue.name : DEFAULT_QUEUE;
+    var queueOptions = ((queue) && (queue.options)) ? queue.options : DEFAULT_QUEUE_OPTIONS;
+    if (!routingKey) routingKey = DEFAULT_ROUTING_KEY;
+
+    console.log("Connecting to " + exchangeName + " with " + exchangeOptions.type +
+                " type for the binding key " + routingKey + " on queue " + queueName);
 
     // NB bind is done async.
     function declareExchangeAndBind(q) {
-      if (bindExchange) {
-        that._connection.exchange(exchangeName, { type: exchangeType },
-                                  function (ex) {
-                                    q.bind(ex, bindingKey);
-                                    callback && callback();
-                                  });
-      }
-      else {
-        callback && callback();
-      }
+        if (exchange) {
+            that._connection.exchange(exchangeName, exchangeOptions,
+                function (ex) {
+                    q.bind(ex, routingKey);
+                    if (callback) callback();
+                });
+        }
+        else {
+            if (callback) callback();
+        }
     }
 
     if (this._privateQueue) {
-      declareExchangeAndBind(this._privateQueue);
+        declareExchangeAndBind(this._privateQueue);
     }
     else {
-      this._connection.queue('', function(q) {
-        that._privateQueue = q;
-        that._subscribe(q, function() {
-          declareExchangeAndBind(q);
-        });
-      });
+       this._connection.queue(queueName, queueOptions, function(q) {
+          that._privateQueue = q;
+          that._subscribe(q, function() {
+              declareExchangeAndBind(q);
+          });
+       });
     }
   };
 
@@ -299,7 +426,7 @@ function Socket(connection) {
         if (that._replies) {
           that._replies.push(msg.replyTo);
         }
-        that._recv(data);
+        that._recv(data, msg);
         data = null;
       });
     }).addCallback(function(ok) {
@@ -309,9 +436,10 @@ function Socket(connection) {
     });
   };
 
-  proto._cancel = function(callback) {
+  proto._cancel = function(deleteQueue, deleteOptions, callback) {
     var that = this;
 
+    if ((deleteQueue) && (!deleteOptions)) deleteOptions = DEFAULT_DELETE_OPTIONS;
     this.readable = false;
     var latch = 0;
 
@@ -321,16 +449,25 @@ function Socket(connection) {
       that.emit('end');
     }
 
-    for (name in this._subscriptions) {
-      var sub = this._subscriptions[name];
-      delete this._subscriptions[name];
-      latch++;
-      sub.queue.unsubscribe(sub.consumerTag).addCallback(function() {
-        latch--;
-        if (latch === 0) {
-          finish();
-        }
-      });
+    for (var name in this._subscriptions) {
+          var sub = this._subscriptions[name];
+          delete this._subscriptions[name];
+          latch++;
+          if (deleteQueue) {
+              sub.queue.destroy(deleteOptions).addCallback(function() {
+                  latch--;
+                  if (latch === 0) {
+                    finish();
+                  }
+              });
+          } else {
+                sub.queue.unsubscribe(sub.consumerTag).addCallback(function() {
+                    latch--;
+                    if (latch === 0) {
+                        finish();
+                    }
+                });
+          }
     }
     // if there are no subscriptions
     if (latch === 0) {
@@ -340,38 +477,39 @@ function Socket(connection) {
 
 })(new Stream());
 
-function PubSocket(connection) {
-  Socket.call(this, connection);
+function PubSocket(connection, qOpts, opts) {
+  Socket.call(this, connection, qOpts);
   this._acceptOpt = {'topic': true};
-  this._opts = {'topic': ''};
+  this._opts = opts || {'topic': ''};
 }
 PubSocket.prototype = new Socket();
 
 PubSocket.prototype.connect = function(exchange, callback) {
   var that = this;
-  this._advertise(
-    exchange, '', function() {
+  this._advertiseExchange(exchange, function() {
       that.writable = true;
       if (callback) callback();
-    });
+  });
 };
-PubSocket.prototype._send = function(buf) {
+PubSocket.prototype._send = function(buf, messageOptions) {
   // TODO account flow control, or lack of confirms, or do something
   // else.
   var rk = this._opts.topic;
+  if (!messageOptions) messageOptions = DEFAULT_MESSAGE_OPTIONS;
+
   this._advertisements.forEach(function(ad) {
-    ad.exchange.publish(rk, buf);
+    ad.exchange.publish(rk, buf, messageOptions);
   });
   return true;
 };
 
-function SubSocket(connection) {
-  Socket.call(this, connection);
+function SubSocket(connection, qOpts) {
+  Socket.call(this, connection, qOpts);
 }
 SubSocket.prototype = new Socket();
-SubSocket.prototype.connect = function(exchange, callback) {
+SubSocket.prototype.connect = function(exchange, routingKey, queue, callback) {
   var that = this;
-  this._consumePrivate(exchange, function() {
+  this._consumePrivate(exchange, routingKey, queue, function() {
     that.readable = true;
     if (callback) callback();
   });
@@ -383,13 +521,13 @@ SubSocket.prototype.connect = function(exchange, callback) {
 // queue dispatch to distribute messages; kind of a two-step
 // round-robin.
 
-function PushSocket(connection) {
-  Socket.call(this, connection);
+function PushSocket(connection, qOpts) {
+  Socket.call(this, connection, qOpts);
 }
 PushSocket.prototype = new Socket();
 PushSocket.prototype.connect = function(queue, callback) {
   var that = this;
-  this._advertise('', queue, function() {
+  this._advertiseQueue(queue, function() {
     that.writable = true;
     if (callback) callback();
   });
@@ -408,15 +546,15 @@ PullSocket.prototype.connect = function(addr, callback) {
   });
 }
 
-function ReqSocket(connection) {
-  Socket.call(this, connection);
+function ReqSocket(connection, qOpts) {
+  Socket.call(this, connection, qOpts);
 }
 ReqSocket.prototype = new Socket();
 ReqSocket.prototype.connect = function(queue, callback) {
   var that = this;
-  this._consumePrivate(false, function() {
+  this._consumePrivate(null, null, null, function() {
     that.readable = true;
-    that._advertise('', queue, function() {
+    that._advertiseQueue(queue, function() {
       that.writable = true;
       if (callback) callback();
     });
@@ -424,8 +562,8 @@ ReqSocket.prototype.connect = function(queue, callback) {
 }
 ReqSocket.prototype._send = ReqSocket.prototype._sendOne;
 
-function RepSocket(connection) {
-  Socket.call(this, connection);
+function RepSocket(connection, qOpts) {
+  Socket.call(this, connection, qOpts);
   this._replies = [];
 }
 RepSocket.prototype = new Socket();
@@ -433,18 +571,19 @@ RepSocket.prototype.connect = function(queue, callback) {
   var that = this;
   // special case: we send back through the default exchange, so just
   // cache that.
-  this._exchange = this._connection.exchange('');
+  this._exchange = this._connection.exchange();
   this._consumeShared(queue, function() {
     that.readable = true;
     if (callback) callback();
   });
 }
-RepSocket.prototype._send = function(data) {
+RepSocket.prototype._send = function(data, messageOptions) {
   // WARNING this requires good behaviour on the part of
   // clients. Specifically: each request must have exactly one reply,
   // and they must be made in order they are sent down the wire. The
   // alternative is to be more like dealer/router, which requires
   // multi-part messages or some prefixing scheme.
   var replyQueue = this._replies.shift();
-  this._exchange.publish(replyQueue, data);
+  if (!messageOptions) messageOptions = DEFAULT_MESSAGE_OPTIONS;
+  this._exchange.publish(replyQueue, data, messageOptions);
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "rabbit.js",
   "description": "Easy stream-based messaging using RabbitMQ",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "homepage": "http://github.com/squaremo/rabbit.js",
   "repository": {
     "type": "git",
@@ -19,7 +19,8 @@
     "node": ">=0.6"
   },
   "dependencies": {
-    "amqp": "git+https://github.com/postwait/node-amqp.git#80fc04991a"
+    "amqp": "git+https://github.com/postwait/node-amqp.git#80fc04991a",
+    "xtend": ">=1.0"
   },
   "devDependencies": {
     "mocha": ""


### PR DESCRIPTION
This change allows users to specify any of the supported options in node-amqp thus giving full control over any resource they create. It also slightly modifies the client API signature to better distinguish between option types (i.e. exchange vs queue vs message) and makes interface clearer. Furthermore it allows to specify a different route key override when writing messages instead of using setsockopt() on every call. Also it is now possible to delete a permanent queue by adding two parameters (queue name and delete options) to the destroy() function. 

The code was carefully written as to not make any changes to the underlying code logic, thereby respecting the original author's intentions. It simply makes certain things more transparent. Because of the slight API change, it requires a minor version number change.
