### PR TITLE
Once we are done with this socket unregister the error handler from the shared connection.

### DIFF
--- a/lib/sockets.js
+++ b/lib/sockets.js
@@ -63,6 +63,10 @@ function Socket(connection) {
     // other shutdown?
   }
   connection.on('error', handle_error);
+  // once we are done with this socket unregister the error handler
+  this.on('end', function(){
+    connection.removeListener('error', handle_error);
+  });
 }
 util.inherits(Socket, Stream);
 


### PR DESCRIPTION
I have been doing some testing and once you roll over 10 sockets you start triggering event emitter errors about maxListeners.

Based on these errors I tracked down the issue to the shared connection having many error_handlers attached to it and no routine to remove them on release of the socket.

Can push a test for this as well if required.
