### PR TITLE
Added pass through for amqplib 'blocked' and 'unblocked' events to allow...

### DIFF
--- a/lib/sockets.js
+++ b/lib/sockets.js
@@ -37,11 +37,12 @@ function Context(url) {
   EventEmitter.call(this);
   var self = this;
   var onError = errorLater(this);
-  var onClose = this.emit.bind(this, 'close');
   var c = this._connection = amqp.connect(url);
   c.then(function(conn) {
     conn.on('error', onError);
-    conn.on('close', onClose);
+    ['close', 'blocked', 'unblocked'].forEach(function(ev) {
+      conn.on(ev, self.emit.bind(self, ev));
+    });
   });
   c.then(this.emit.bind(this, 'ready')).then(null, onError);
 };


### PR DESCRIPTION
... registration of handlers.

amqplib emits a 'blocked' event when a RabbitMQ server (after version 3.2.0) decides to block the connection. Typically it will do this if there is some resource shortage, e.g., memory, and messages are published on the connection. 

It then emits an 'unblocked' event at some time after 'blocked', once the resource shortage has alleviated.

Confirmed all existing tests were passing before committing the code. Will need to use stubs in order to unit test this additional functionality, as actually causing a resource constraint in RabbitMQ stops the existing tests from running.
