### PR TITLE
Added requeue and discard functionality to socket

### DIFF
--- a/lib/sockets.js
+++ b/lib/sockets.js
@@ -363,7 +363,7 @@ WorkerSocket.prototype.discard = function() {
         throw new Error("discard called with no unacknowledged messages");
     }
 
-    this.ch.reject(msg, false);
+    this.ch.nack(msg, false, false);
 };
 
 
@@ -510,7 +510,7 @@ RepSocket.prototype.discard = function() {
     if (!current)
         throw new Error('Discard with no pending request');
 
-    ch.reject(current, false);
+    ch.nack(current, false, false);
 };
 
 


### PR DESCRIPTION
Per issue #65: https://github.com/squaremo/rabbit.js/issues/65, I've created two new methods, requeue and discard, on the Request/Reply and Push/Worker sockets.  

Requeue calls the amqp#nack() method with only the msg argument, in amqp, requeue is defaulted to true.

Discard calls the amqp#reject method, with a requeue flag set explicitly to false.

Method methods remove the current message from the unacked queue to enable the sequence to continue. 
