### PR TITLE
Pass autoDelete option to SubSocket

### DIFF
--- a/lib/sockets.js
+++ b/lib/sockets.js
@@ -179,7 +179,7 @@ PubSocket.prototype.connect = function(destination, callback) {
   var self = this, ch = this.ch;
   ch.assertExchange(destination,
                     this.options.routing || 'fanout',
-                    {durable: false, autoDelete: false})
+                    {durable: false, autoDelete: this.options.autoDelete || false})
     .then(function(ok) {
       self.pubs.push(destination);
     }).then(callback);


### PR DESCRIPTION
I use rabbit.js with socket.io this way: when connection (between browser and nodejs) open it creates it's own unique SubSocket so backend can publish messages directly client. 
If flag autoDelete set to false rabbitMq keeps all of this unique (and already useless) exchanges after socket.io closes connection and it's count grow to hundreds, that is at least annoying.
