### PR TITLE
set priority to push socket when writing

### DIFF
--- a/lib/sockets.js
+++ b/lib/sockets.js
@@ -157,6 +157,7 @@ function setsockopt(opt, value) {
   case 'persistent':
   case 'topic':
   case 'task':
+  case 'priority':
     this.options[opt] = value; break;
   }
 }
@@ -276,7 +277,8 @@ PushSocket.prototype.write = function(chunk, encoding) {
   if (queue !== undefined) {
     this.queues.push(queue);
     var options = {expiration: this.options.expiration,
-                   persistent: this.options.persistent};
+                   persistent: this.options.persistent,
+                   priority:   this.options.priority};
     return this.ch.sendToQueue(queue,
                                bufferify(chunk, encoding), options);
   }


### PR DESCRIPTION
i'd like to use this package for my rabbit queue that is using the priority queue plugin (https://github.com/rabbitmq/rabbitmq-priority-queue). for the queue to rearrange itself, i need to send priority over as a property
