### PR TITLE
pass connection options via createContext through to amqplib

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 var sockets = require('./lib/sockets');
 
-module.exports.createContext = function(url) {
-  return new sockets.Context(url);
+module.exports.createContext = function(url, connOpts) {
+  return new sockets.Context(url, connOpts);
 }

--- a/lib/sockets.js
+++ b/lib/sockets.js
@@ -33,11 +33,11 @@ function errorLater(obj) {
 function ignore() {} // for stubbing out methods I don't care about;
                      // i.e., _read
 
-function Context(url) {
+function Context(url, connOpts) {
   EventEmitter.call(this);
   var self = this;
   var onError = errorLater(this);
-  var c = this._connection = amqp.connect(url);
+  var c = this._connection = amqp.connect(url, connOpts);
   c.then(function(conn) {
     conn.on('error', onError);
     ['close', 'blocked', 'unblocked'].forEach(function(ev) {


### PR DESCRIPTION
Hi,
Added an optional connection options parameter to createContext() in order to support SSL connections. The connection options are passed through to the amqplib's connect() call.
Hope this is useful for anyone else,
Toby
