### PR TITLE
Support existing exchanges with durable: true.

### DIFF
--- a/lib/sockets.js
+++ b/lib/sockets.js
@@ -251,7 +251,7 @@ SubSocket.prototype.connect = function(source, topic, callback) {
   else {
     ch.assertExchange(source,
                       this.options.routing || 'fanout',
-                      {durable: false, autoDelete: false})
+                      {durable: this.options.persistent, autoDelete: false})
       .then(function(ok) {
         return ch.bindQueue(queue, source, topic);
       })


### PR DESCRIPTION
In order to support existing AMQP exchanges with bindings that is setup with durable=true, this needs to be populated via the PubSocket API. Current implementation has durable hardcoded to false.
