### PR TITLE
Allow for distributed (round-robin) SubSockets via `sharedQueue` option

### DIFF
--- a/lib/sockets.js
+++ b/lib/sockets.js
@@ -459,7 +459,7 @@ ReqSocket.prototype.connect = function(destination, callback) {
   var self = this, ch = this.ch;
 
   if (this.options.noCreate) {
-      self.queues.push(ok.queue);
+      self.queues.push(destination);
     delay(callback);
   }
   else {

--- a/lib/sockets.js
+++ b/lib/sockets.js
@@ -366,12 +366,14 @@ WorkerSocket.prototype.connect = function(source, callback) {
     if (callback) delay(callback); return;
   }
 
+  var options = this.options || {};
+
   function consume() {
     return ch.consume(source, function(msg) {
       if (msg) self.unacked.push(msg);
       self.push(msg && msg.content);
     }, {
-      autoDelete: !!this.options.autoDelete,
+      autoDelete: !!options.autoDelete,
       noAck: false
     }).then(function(ok) {
       self.consumers[source] = ok.consumerTag;

--- a/lib/sockets.js
+++ b/lib/sockets.js
@@ -219,16 +219,22 @@ function SubSocket(channel, opts) {
   this.subs = [], this.patterns = [];
   var self = this;
 
+  var subQueue = opts && opts.sharedQueue ? opts.sharedQueue : '';
+  var hasSubQueue = !subQueue.length;
+
+  var noAck = opts && opts.noAck || true;
+
   var setup = channel.then(function(ch) {
-    return ch.assertQueue('', {
-      exclusive: true, autoDelete: true
+    return ch.assertQueue(subQueue, {
+      exclusive: hasSubQueue,
+      autoDelete: !hasSubQueue
     }).then(function(ok) {
       self.queue = ok.queue; // for inspection
       return ch.consume(ok.queue, function(msg) {
         // if msg is null, this indicates a cancel, i.e., end of
         // stream. Pushing such a null tells the stream to emit 'end'.
         self.push(msg && msg.content);
-      }, {noAck:true, exclusive:true})
+      }, {noAck: noAck, exclusive: hasSubQueue})
         .then(function() { return ch; });
     });
   });

--- a/lib/sockets.js
+++ b/lib/sockets.js
@@ -370,7 +370,10 @@ WorkerSocket.prototype.connect = function(source, callback) {
     return ch.consume(source, function(msg) {
       if (msg) self.unacked.push(msg);
       self.push(msg && msg.content);
-    }, {noAck:false}).then(function(ok) {
+    }, {
+      autoDelete: !!this.options.autoDelete,
+      noAck: false
+    }).then(function(ok) {
       self.consumers[source] = ok.consumerTag;
     }).then(callback);
   }

--- a/lib/sockets.js
+++ b/lib/sockets.js
@@ -290,7 +290,10 @@ PushSocket.prototype.connect = function(destination, callback) {
     delay(callback);
   }
   else {
-    ch.assertQueue(destination, {durable: this.options.persistent})
+    ch.assertQueue(destination, {
+      durable: this.options.persistent,
+      autoDelete: !!this.options.autoDelete
+    })
       .then(function(ok) {
         self.queues.push(destination);
       }).then(callback);


### PR DESCRIPTION
I was looking to be able to have a number of service instances subscribe to a wildcard topic, and have those instances round-robin the messages, and rather than write my own or just monkey-patch `rabbit.js`, I thought I'd just make the change.

Added a test, too.
