### PR TITLE
Add the subSocket custom queue name function

### DIFF
--- a/lib/sockets.js
+++ b/lib/sockets.js
@@ -220,8 +220,8 @@ function SubSocket(channel, opts) {
   var self = this;
 
   var setup = channel.then(function(ch) {
-    return ch.assertQueue('', {
-      exclusive: true, autoDelete: true
+    return ch.assertQueue(self.options.queue || '', {
+      exclusive: (self.options.queue?false:true), autoDelete: true
     }).then(function(ok) {
       self.queue = ok.queue; // for inspection
       return ch.consume(ok.queue, function(msg) {


### PR DESCRIPTION
I have a need for multiple programs to consume a queue together, so I need to customize the queue name, and exclusive = false